### PR TITLE
Use correct image of CPU usage

### DIFF
--- a/docs/real-usecase/first-usage.md
+++ b/docs/real-usecase/first-usage.md
@@ -45,7 +45,7 @@ After *kube-green*, it is possible to see the memory lines with 5 peak in the wo
 
 It is possible to see the same as for memory also for the CPU in the following image.  
 
-![Memory usage](/img/usecase/23.7-23-8-memory.png)
+![Memory usage](/img/usecase/23.7-23-8-CPU.png)
 
 ### Numeric summary
 


### PR DESCRIPTION
As seen on the website at https://kube-green.dev/docs/real-usecase/first-usage/ the image for CPU usage is identical to the image for memory usage. It seems that the correct image is the image I have changed it to in this PR which is located at https://github.com/kube-green/kube-green.github.io/tree/main/static/img/usecase

![image](https://user-images.githubusercontent.com/16527874/223522525-93c21b0c-2901-4282-863a-63f1b2750fbb.png)