### PR TITLE
fix: Fix typo in configuration docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,7 +136,7 @@ spec:
   wakeUpAt: "08:00"
   timeZone: "Europe/Rome"
   suspendCronJobs: true
-  excludeRef:
+  includeRef:
     - matchLabels: 
         kube-green.dev/include: true
 ```


### PR DESCRIPTION
Closes: [#499](https://github.com/kube-green/kube-green/issues/499)